### PR TITLE
Upgrade to Spring Boot 2.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,35 @@ git clone https://github.com/oktadev/okta-spring-boot-test-slices-example.git
 cd okta-spring-boot-test-slices-example
 ```
 
-Start local development environment
+### Create an OIDC App
+
+Before you begin, you'll need a free Okta developer account. Install the [Okta CLI](https://cli.okta.com/) and run `okta register` to sign up for a new account. If you already have an account, run `okta login`. Then, run `okta apps create`. Select the default app name, or change it as you see fit. Choose **Web** and press **Enter**.
+
+Select **Okta Spring Boot Starter**. Accept the default Redirect URI values provided for you. That is, a Login Redirect of `http://localhost:8080/login/oauth2/code/okta` and a Logout Redirect of `http://localhost:8080`.
+
+## Run Your Spring Boot App
+
+Start local development environment:
+
 ```
 docker-compose -f docker-compose.devenv.yml up
 ```
 
-In another console start the app
+In another console start the app:
+
 ```
 ./gradlew bootRun
 ```
+
 Then, open `http://localhost:8080` in your favorite browser to see service working.
+
+## Test Your Spring Boot App
+
+Run the following command to execute all the tests:
+
+```
+./gradlew test
+```
 
 ## Help
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,13 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "2.5.1"
+    id("org.springframework.boot") version "2.6.3"
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
-    id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
-    id("com.adarshr.test-logger") version "3.0.0"
-    kotlin("jvm") version "1.5.10"
-    kotlin("plugin.spring") version "1.5.10"
-    kotlin("plugin.jpa") version "1.5.10"
+    id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
+    id("com.adarshr.test-logger") version "3.1.0"
+    kotlin("jvm") version "1.6.10"
+    kotlin("plugin.spring") version "1.6.10"
+    kotlin("plugin.jpa") version "1.6.10"
 }
 
 group = "com.example.okta"
@@ -24,10 +24,10 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-mustache")
     implementation("org.postgresql:postgresql")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("com.okta.spring:okta-spring-boot-starter:2.0.1")
+    implementation("com.okta.spring:okta-spring-boot-starter:2.1.4")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    implementation("org.junit.jupiter:junit-jupiter:5.4.2")
+    implementation("org.junit.jupiter:junit-jupiter:5.8.2")
     runtimeOnly("org.postgresql:postgresql")
     testRuntimeOnly("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/docker-compose.devenv.yml
+++ b/docker-compose.devenv.yml
@@ -7,7 +7,7 @@ version: "3.9"
 
 services:
   db:
-    image: postgres:13.2
+    image: postgres:14.1
     ports:
       - 5432:5432
     volumes:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
-#Tue Feb 08 14:39:37 MST 2022
-spring.datasource.url=jdbc\:postgresql\://localhost\:5432/demodb
+#Sun Mar 28 18:59:07 BST 2021
+spring.datasource.url=jdbc:postgresql://localhost:5432/demodb
 spring.datasource.username=demouser
 spring.datasource.password=demopass
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,10 @@
-#Sun Mar 28 18:59:07 BST 2021
-spring.datasource.url=jdbc:postgresql://localhost:5432/demodb
+#Tue Feb 08 14:39:37 MST 2022
+spring.datasource.url=jdbc\:postgresql\://localhost\:5432/demodb
 spring.datasource.username=demouser
 spring.datasource.password=demopass
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=create
 spring.mustache.cache=false
+okta.oauth2.issuer=https\://dev-2530788.okta.com/oauth2/default
+okta.oauth2.client-id=0oa3u46gbypTkqDaP5d7
+okta.oauth2.client-secret=OU_r1syMOHmDBYEfaYgo_Eu7moTMjsFGSAT1mCvl

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,3 @@ spring.datasource.password=demopass
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=create
 spring.mustache.cache=false
-okta.oauth2.issuer=https\://dev-2530788.okta.com/oauth2/default
-okta.oauth2.client-id=0oa3u46gbypTkqDaP5d7
-okta.oauth2.client-secret=OU_r1syMOHmDBYEfaYgo_Eu7moTMjsFGSAT1mCvl


### PR DESCRIPTION
Currently fails with the following error when running `./gradlew test`:

```
> Task :compileTestKotlin FAILED
e: /Users/mraible/dev/okta/okta-spring-boot-test-slices-example/src/test/kotlin/com/example/okta/testslices/service/ViewersServiceIntegrationTest.kt: (36, 14): Overload resolution ambiguity: 
public open fun satisfies(p0: Consumer<in ViewerModel!>!): ObjectAssert<ViewerModel!>! defined in org.assertj.core.api.ObjectAssert
public open fun satisfies(p0: ThrowingConsumer<in ViewerModel!>!): ObjectAssert<ViewerModel!>! defined in org.assertj.core.api.ObjectAssert
e: /Users/mraible/dev/okta/okta-spring-boot-test-slices-example/src/test/kotlin/com/example/okta/testslices/service/ViewersServiceIntegrationTest.kt: (37, 28): Unresolved reference: it
e: /Users/mraible/dev/okta/okta-spring-boot-test-slices-example/src/test/kotlin/com/example/okta/testslices/service/ViewersServiceIntegrationTest.kt: (38, 28): Unresolved reference: it
e: /Users/mraible/dev/okta/okta-spring-boot-test-slices-example/src/test/kotlin/com/example/okta/testslices/service/ViewersServiceIntegrationTest.kt: (54, 14): Overload resolution ambiguity: 
public open fun satisfies(p0: Consumer<in ViewerModel!>!): ObjectAssert<ViewerModel!>! defined in org.assertj.core.api.ObjectAssert
public open fun satisfies(p0: ThrowingConsumer<in ViewerModel!>!): ObjectAssert<ViewerModel!>! defined in org.assertj.core.api.ObjectAssert
e: /Users/mraible/dev/okta/okta-spring-boot-test-slices-example/src/test/kotlin/com/example/okta/testslices/service/ViewersServiceIntegrationTest.kt: (55, 28): Unresolved reference: it
e: /Users/mraible/dev/okta/okta-spring-boot-test-slices-example/src/test/kotlin/com/example/okta/testslices/service/ViewersServiceIntegrationTest.kt: (56, 28): Unresolved reference: it
```

Do you have any idea how to fix @ruXlab? 